### PR TITLE
Properly format styleguide links so they can be clicked

### DIFF
--- a/lib/init/config-initializer.js
+++ b/lib/init/config-initializer.js
@@ -494,9 +494,9 @@ function promptUser() {
             name: "styleguide",
             message: "Which style guide do you want to follow?",
             choices: [
-                { name: "Airbnb (https://github.com/airbnb/javascript)", value: "airbnb" },
-                { name: "Standard (https://github.com/standard/standard)", value: "standard" },
-                { name: "Google (https://github.com/google/eslint-config-google)", value: "google" }
+                { name: "Airbnb ( https://github.com/airbnb/javascript )", value: "airbnb" },
+                { name: "Standard ( https://github.com/standard/standard )", value: "standard" },
+                { name: "Google ( https://github.com/google/eslint-config-google )", value: "google" }
             ],
             when(answers) {
                 answers.packageJsonExists = npmUtils.checkPackageJson();


### PR DESCRIPTION
<!--
    ESLint adheres to the [JS Foundation Code of Conduct](https://js.foundation/community/code-of-conduct).
-->

**What is the purpose of this pull request? (put an "X" next to item)**

[ x ] Other, please explain:

<!--
    If the item you've checked above has a template, please paste the template questions below and answer them. (If this pull request is addressing an issue, you can just paste a link to the issue here instead.)
-->


**What changes did you make? (Give an overview)**

When using the initializer and coming to style guide step, visual studio code terminal doesn't properly format style guide links so when user clicks on one of the links it takes them to e.q `https://github.com/airbnb/javascript)` (note the `)` at the end) 
Putting spaces after the opening brace and before the closing brace fixes this issue.
**Is there anything you'd like reviewers to focus on?**
No

